### PR TITLE
isolation option for slave and exit status of status_of_proc

### DIFF
--- a/debian/master.init
+++ b/debian/master.init
@@ -48,7 +48,7 @@ stop_mesos() {
 
 status_mesos() {
     if (type status_of_proc > /dev/null 2>&1) ; then
-        status_of_proc -p "${PIDFILE}" "${DAEMON}" "${NAME}"
+        status_of_proc -p "${PIDFILE}" "${DAEMON}" "${NAME}" && exit 0 || exit $?
     else
         status_of_proc() {
             local pidfile daemon name status

--- a/debian/slave.init
+++ b/debian/slave.init
@@ -31,6 +31,7 @@ go_daemon() {
     ${IP:+--ip=$IP} \
     ${PORT:+--port=$PORT} \
     ${WORKDIR:+--work_dir=$WORKDIR} \
+    ${ISOLATION:+--isolation=$ISOLATION} \
     $OPTS \
     >> "$LOGS"/slave.log 2>&1
 }
@@ -46,7 +47,7 @@ stop() {
 
 status_mesos() {
     if (type status_of_proc > /dev/null 2>&1) ; then
-        status_of_proc -p "${PIDFILE}" "${DAEMON}" "${NAME}"
+        status_of_proc -p "${PIDFILE}" "${DAEMON}" "${NAME}" && exit 0 || exit $?
     else
         status_of_proc() {
             local pidfile daemon name status


### PR DESCRIPTION
That pull adding option to handle isolation variable for debian slaves and fixing fallowing bug:

root@job1(00:06:35):~$ /etc/init.d/mesos-slave status
[FAIL] mesos-slave is not running ... failed!
status_of_proc -p "/var/run/mesos-slave.pid" "/usr/local/sbin/mesos-slave" "mesos-slave"
root@job1(00:06:39):~$ echo $?
0
