### PR TITLE
Update init wrapper to enable IP conf for master

### DIFF
--- a/mesos-init-wrapper
+++ b/mesos-init-wrapper
@@ -112,6 +112,7 @@ function master {
   [[ ! ${ULIMIT:-} ]]  || ulimit $ULIMIT
   [[ ! ${ZK:-} ]]      || args+=( --zk="$ZK" )
   [[ ! ${PORT:-} ]]    || args+=( --port="$PORT" )
+  [[ ! ${IP:-} ]]      || args+=( --ip="$IP" )
   [[ ! ${CLUSTER:-} ]] || args+=( --cluster="$CLUSTER" )
   [[ ! ${LOGS:-} ]]    || args+=( --log_dir="$LOGS" )
 


### PR DESCRIPTION
This commit enables setting the listening IP on the mesos-master via /etc/default/mesos or /etc/default/mesos-master.

For when you want to have the master listening to another IP.

Thanks!
