### PR TITLE
Make mesos pre/post scripts tolerate it when mesos isn't running

### DIFF
--- a/debian/mesos.postinst
+++ b/debian/mesos.postinst
@@ -5,7 +5,7 @@ case "$1" in
   configure)
     #update paths to libmesos.so
     ldconfig
-    if [ -f /tmp/mesos-master-reload ]; then
+    if [ -f /tmp/mesos-master-reload ] && pgrep mesos-master >/dev/null; then
       if [ -x /etc/init.d/mesos-master ]; then
         update-rc.d mesos-master defaults
         /etc/init.d/mesos-master start
@@ -15,7 +15,7 @@ case "$1" in
       rm /tmp/mesos-master-reload
     fi
 
-    if [ -f /tmp/mesos-slave-reload ]; then
+    if [ -f /tmp/mesos-slave-reload ]  && pgrep mesos-slave >/dev/null; then
       if [ -x /etc/init.d/mesos-slave ]; then
         update-rc.d mesos-slave defaults
         /etc/init.d/mesos-slave start

--- a/debian/mesos.preinst
+++ b/debian/mesos.preinst
@@ -12,7 +12,7 @@ case "$1" in
    ;;
 
   upgrade)
-   if [ -f /var/run/mesos-master.pid ]; then
+   if [ -f /var/run/mesos-master.pid ] && pgrep mesos-master >/dev/null; then
      touch /tmp/mesos-master-reload
      if [ -x /etc/init.d/mesos-master ]; then
        /etc/init.d/mesos-master stop
@@ -20,7 +20,7 @@ case "$1" in
        upstart_stop "mesos-master"
      fi
    fi
-   if [ -f /var/run/mesos-slave.pid ]; then
+   if [ -f /var/run/mesos-slave.pid ] && pgrep mesos-slave >/dev/null; then
      touch /tmp/mesos-slave-reload
      if [ -x /etc/init.d/mesos-slave ]; then
        /etc/init.d/mesos-slave stop

--- a/debian/mesos.prerm
+++ b/debian/mesos.prerm
@@ -3,7 +3,7 @@ set -e
 
 case "$1" in
   upgrade|remove|remove-in-favour|deconfigure|deconfigure-in-favour)
-    if [ -f /var/run/mesos-master.pid ]; then
+    if [ -f /var/run/mesos-master.pid ] && pgrep mesos-master >/dev/null; then
       if [ -x /etc/init.d/mesos-master ]; then
          /etc/init.d/mesos-master stop
       elif [ -f /etc/init/mesos-master.conf ]; then
@@ -11,7 +11,7 @@ case "$1" in
       fi
     fi
 
-    if [ -f /var/run/mesos-slave.pid ]; then
+    if [ -f /var/run/mesos-slave.pid ] && pgrep mesos-slave >/dev/null; then
       if [ -x /etc/init.d/mesos-slave ]; then
         /etc/init.d/mesos-slave stop
       elif [ -f /etc/init/mesos-slave.conf ]; then


### PR DESCRIPTION
I have this situation all the time where I screw up mesos in such a way that it crashes, bad config, whatever.

So when I try to fix my issue by upgrading mesos (with puppet, via the package), I cannot, because set -e.

This makes the scripts slightly more tolerant of these situations by only trying to stop the service if the process is actually in the process tree.
