### PR TITLE
Enable default respawn limit

### DIFF
--- a/ubuntu/master.upstart
+++ b/ubuntu/master.upstart
@@ -5,7 +5,9 @@ description "mesos master"
 # Ubuntu, Debian, CentOS, and RHEL distros. See:
 # http://upstart.ubuntu.com/cookbook/#standard-idioms
 start on stopped rc RUNLEVEL=[2345]
+
 respawn
+respawn limit 3 420
 
 script
     [ -r /etc/default/mesos ] && . /etc/default/mesos

--- a/ubuntu/slave.upstart
+++ b/ubuntu/slave.upstart
@@ -5,7 +5,9 @@ description "mesos slave"
 # Ubuntu, Debian, CentOS, and RHEL distros. See:
 # http://upstart.ubuntu.com/cookbook/#standard-idioms
 start on stopped rc RUNLEVEL=[2345]
+
 respawn
+respawn limit 3 420
 
 script
     [ -r /etc/default/mesos ] && . /etc/default/mesos


### PR DESCRIPTION
I do this on my own fork.
I have some monitoring on the mesos slave, and it was not triggering because upstart was respawning the mesos slave so fast, but the mesos slave was _not_ healthy.

This adds a limit. The mesos slave takes a while to crash, so by default the normal respawn limit is not triggered.
