### PR TITLE
Revert the mesos slave upstart script

### DIFF
--- a/upstart/master.upstart
+++ b/upstart/master.upstart
@@ -13,8 +13,5 @@ script
     [ -r /etc/default/mesos ] && . /etc/default/mesos
     DAEMON="/usr/local/sbin/mesos-master"
     MESOS_MASTER_OPTS=$(/usr/bin/mesos-init-wrapper master)
-    exec start-stop-daemon --start --make-pidfile --name mesos-master \
-        --pidfile /var/run/mesos-master.pid --startas /bin/bash -- -c "exec $DAEMON $MESOS_MASTER_OPTS"
-
+    exec ${DAEMON} ${MESOS_MASTER_OPTS}
 end script
-

--- a/upstart/slave.upstart
+++ b/upstart/slave.upstart
@@ -13,16 +13,12 @@ script
     [ -r /etc/default/mesos ] && . /etc/default/mesos
     DAEMON="/usr/local/sbin/mesos-slave"
     MESOS_SLAVE_OPTS=$(/usr/bin/mesos-init-wrapper slave)
-    PIDFILE=/var/run/mesos-slave.pid
 
-    [[ ! -f /etc/default/mesos-slave ]] || . /etc/default/mesos-slave
-    [[ ! ${ULIMIT_OPEN_FILES:-} ]]    || ulimit -n $ULIMIT_OPEN_FILES
-    [[ ! ${ULIMIT_MAX_PROCESSES:-} ]]    || ulimit -u $ULIMIT_MAX_PROCESSES
-    [[ ! ${ULIMIT_PENDING_SIGNALS:-} ]]    || ulimit -i $ULIMIT_PENDING_SIGNALS
+    [ ! -f /etc/default/mesos-slave ] || . /etc/default/mesos-slave
+    [ ! ${ULIMIT_OPEN_FILES:-} ]      || ulimit -n $ULIMIT_OPEN_FILES
+    [ ! ${ULIMIT_MAX_PROCESSES:-} ]   || ulimit -u $ULIMIT_MAX_PROCESSES
+    [ ! ${ULIMIT_PENDING_SIGNALS:-} ] || ulimit -i $ULIMIT_PENDING_SIGNALS
 
-    su -l -c "start-stop-daemon --start --background --quiet \
-                     --pidfile \"$PIDFILE\" --make-pidfile \
-                     --startas /bin/bash -- -c \"exec $DAEMON $SLAVE_OPTS\" "
-
+    exec ${DAEMON} ${MESOS_SLAVE_OPTS}
 end script
 


### PR DESCRIPTION
This reverts the mesos-slave upstart script back to the way it was.

The su -l version looks copy+pasted from the sysv init version, and is _extremely_ complicated. It doesn't work anyway because of the mismatch between SLAVE_OPTS and MESOS_SLAVE_OPTS. Does anyone use this for real?

Anyway, this is all silly to use su + start-stop-daemon + bash + exec + mesos-slave when upstart could just run mesos-slave directly. 

Would you accept a PR to make this just... run the thing?

```
${DAEMON} ${MESOS_SLAVE_OPTS}
```

I mean, why are we making it more complicated than it needs to be? 

cc @mrtyler
