### PR TITLE
Fix error when "--src-dir" used without "--ref".

### DIFF
--- a/build_mesos
+++ b/build_mesos
@@ -145,7 +145,7 @@ function checkout {
   local repository="${url[0]}"
   local query="${url[1]:-}"
 
-  if [[ -z "$ref" ]]; then
+  if [[ ! -v ref ]]; then
     if [[ ${url[2]:-} ]]
     then err "Setting fragment (#) does nothing. Try query (?) instead."
     fi


### PR DESCRIPTION
If "--ref" is not specified, the variable is left undefined, so "-z" cannot be
used.