### PR TITLE
Correct separation of multiple attributes/resources

### DIFF
--- a/mesos-init-wrapper
+++ b/mesos-init-wrapper
@@ -95,7 +95,7 @@ function slave {
   if [[ ${#attributes[@]} -gt 0 ]]
   then
     local formatted="$(printf ';%s' "${attributes[@]}")"
-    args+=( --attributes="${formatted:1}" )        # NB: Leading ';' is clipped
+    args+=( --attributes="\"${formatted:1}\"" )        # NB: Leading ';' is clipped
   fi
   for f in "$etc_slave"/resources/*
   do [[ ! -s $f ]] || resources+=( "$(basename "$f")":"$(cat "$f")" )
@@ -103,7 +103,7 @@ function slave {
   if [[ ${#resources[@]} -gt 0 ]]
   then
     local formatted="$(printf ';%s' "${resources[@]}")"
-    args+=( --resources="${formatted:1}" )         # NB: Leading ';' is clipped
+    args+=( --resources="\"${formatted:1}\"" )         # NB: Leading ';' is clipped
   fi
   logged /usr/sbin/mesos-slave "${args[@]}"
 }


### PR DESCRIPTION
Hey guys,

when I'm using mesos-init-wrapper as it is on Ubuntu(14.04 - upstart), then I can't start the mesos-slave.
If we want to use a semicolon for delimiting multiple attributes/resources then we have to put whole argument between quotes, otherwise the second argument (right after the semicolon) is evaluated as a new command by Bash. Another approach to this problem is using a comma instead of semicolon on lines 97 and 105. Then we don't need quotation of whole attributes/resources arguments and it's closer to what the mesos-slave documentation says.

Cheers,
R.